### PR TITLE
switch to moderngl

### DIFF
--- a/.github/workflows/CinemaRenderTest.yml
+++ b/.github/workflows/CinemaRenderTest.yml
@@ -12,17 +12,20 @@ jobs:
         python-version: [3.9]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        sudo apt-get install freeglut3-dev # can be removed after switch from PyOpenGL to moderngl
-        python setup.py install
-    - name: Run headless rendering tests
-      uses: GabrielBB/xvfb-action@v1
-      with:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Test Environment
         run: |
-          python -m unittest testing/CinemaRenderTest.py
+          python -m pip install --upgrade pip
+          sudo apt-get install libglu1-mesa-dev xvfb
+          python -m pip install pytest pytest-xvfb
+      - name: Dependencies
+        run: |
+          python setup.py install
+      - name: Test using ModernGL
+        run: |
+          python -m pytest -s testing/CinemaRenderTest.py
+

--- a/cinemasci/ImageRenderer.py
+++ b/cinemasci/ImageRenderer.py
@@ -1,46 +1,50 @@
 from .Core import *
 
-from OpenGL.GL import *
-from OpenGL.GLUT import *
-from OpenGL.GL import shaders
-from OpenGL.GL import glGetString
 import numpy as np
-
+import moderngl
 from PIL import Image
 
 class ImageRenderer(Filter):
     def __init__(self):
-        super(ImageRenderer, self).__init__();
-        self.addInputPort("Image", "List", []);
-        self.addOutputPort("Image", "List", []);
+        super(ImageRenderer, self).__init__()
+        self.addInputPort("Image", "List", [])
+        self.addOutputPort("Image", "List", [])
 
-        # create context once
-        glutInit()
-        glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB)
+        # create context
+        self.ctx = moderngl.create_standalone_context()
 
-    def compileShader(self, shader_code, shader_type):
-        try:
-            shader_id = glCreateShader(shader_type)
-            glShaderSource(shader_id, shader_code)
-            glCompileShader(shader_id)
-            if glGetShaderiv(shader_id, GL_COMPILE_STATUS) != GL_TRUE:
-                info = glGetShaderInfoLog(shader_id)
-                raise RuntimeError('Shader compilation failed: %s' % (info))
-            return shader_id
-        except:
-            glDeleteShader(shader_id)
-            raise
+        # fullscreen quad
+        vertices = np.array([
+          1.0,  1.0,
+          -1.0,  1.0,
+          -1.0, -1.0,
+          -1.0, -1.0,
+           1.0, -1.0,
+           1.0,  1.0
+        ])
+        self.quad = self.ctx.buffer(vertices.astype('f4').tobytes())
+
+        # program
+        self.program = self.ctx.program(
+          vertex_shader=self.getVertexShaderCode(),
+          fragment_shader=self.getFragmentShaderCode(),
+          varyings=["vUV"]
+        )
+        self.program['tex'] = 0
+
+        self.vao = self.ctx.simple_vertex_array(self.program, self.quad, 'position')
 
     def getVertexShaderCode(self):
         return """
 #version 120
 
-attribute vec3 position;
+attribute vec2 position;
 varying vec2 vUV;
 
 void main(){
-    vUV = position.xy/2. + vec2(0.5);
-    gl_Position = vec4(position,1);
+    vUV = position/2. + vec2(0.5);
+    vUV.y = -vUV.y;
+    gl_Position = vec4(position,0,1);
 }
         """
 
@@ -55,89 +59,29 @@ varying vec2 vUV;
 void main(){
     vec4 c = texture2D(tex,vUV);
     gl_FragColor = vec4(vec3(0.299*c.r + 0.587*c.g + 0.114*c.b),1);
-    // fout_color = c;
-    // fout_color = vec4(vUV.yx,0,1);
-    // fout_color = vec4(1,0,1,1);
+    // gl_FragColor = c;
+    // gl_FragColor = vec4(vUV.xy,0,1);
 }
         """
 
     def render(self,image):
 
-        width = image.shape[1]
-        height = image.shape[0]
-
-        # Setup framebuffer
-        framebuffer = glGenFramebuffers (1)
-        glBindFramebuffer(GL_FRAMEBUFFER, framebuffer)
-
-        # Setup colorbuffer
-        colorbuffer = glGenRenderbuffers (1)
-        glBindRenderbuffer(GL_RENDERBUFFER, colorbuffer)
-        glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA, width, height)
-        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, colorbuffer)
-
-        # Setup depthbuffer
-        depthbuffer = glGenRenderbuffers (1)
-        glBindRenderbuffer(GL_RENDERBUFFER,depthbuffer)
-        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, width, height)
-        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthbuffer)
-
-        # check status
-        status = glCheckFramebufferStatus(GL_FRAMEBUFFER)
-        if status != GL_FRAMEBUFFER_COMPLETE:
-            print( "!!! Error in framebuffer activation")
-            return
-
-        # initialize view port
-        glViewport(0, 0, width, height)
-        glClearColor(0, 1, 0, 1.0)
-        glClear(GL_COLOR_BUFFER_BIT)
-
         # create texture
-        textID = glGenTextures(1)
-        glBindTexture(GL_TEXTURE_2D, textID)
+        texture = self.ctx.texture(image.shape[1::-1], image.shape[2], image)
+        texture.use(location=0)
 
-        img_data = np.array(image, np.int8)
-        glPixelStorei(GL_UNPACK_ALIGNMENT, 1)
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP)
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP)
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT)
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT)
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
-        glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_DECAL)
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, img_data)
-        glEnable(GL_TEXTURE_2D)
+        # create framebuffer
+        fbo = self.ctx.simple_framebuffer((image.shape[0], image.shape[1]))
+        fbo.use()
+        fbo.clear(0.0, 0.0, 0.0, 1.0)
+        self.vao.render(moderngl.TRIANGLE_STRIP)
 
-        # create shader
-        self.shader = glCreateProgram()
-        vs_id = self.compileShader(self.getVertexShaderCode(), GL_VERTEX_SHADER)
-        frag_id = self.compileShader(self.getFragmentShaderCode(), GL_FRAGMENT_SHADER)
-        glAttachShader(self.shader, vs_id)
-        glAttachShader(self.shader, frag_id)
-        glLinkProgram(self.shader)
-        glUseProgram(self.shader)
+        # read pixels
+        image = Image.frombytes('RGB', fbo.size, fbo.read(), 'raw', 'RGB', 0, -1)
 
-        # draw fullscreen quad
-        glBegin(GL_QUADS) # Begin the sketch
-        glVertex2f(-1, -1) # Coordinates for the bottom left point
-        glVertex2f(1, -1) # Coordinates for the bottom right point
-        glVertex2f(1, 1) # Coordinates for the top right point
-        glVertex2f(-1, 1) # Coordinates for the top left point
-        glEnd() # Mark the end of drawing
-
-        glFlush()
-
-        # read pixel data
-        glReadBuffer(GL_COLOR_ATTACHMENT0)
-        glPixelStorei(GL_PACK_ALIGNMENT, 1)
-        data = glReadPixels (0, 0, width, height, GL_RGB,  GL_UNSIGNED_BYTE)
-        image = Image.new ("RGB", (width, height), (0, 0, 0))
-        image.frombytes(data)
-
-        # clean up
-        glDeleteTextures([textID])
-        glDeleteFramebuffers (1,[framebuffer])
+        # release resources
+        texture.release()
+        fbo.release()
 
         return image
 
@@ -145,18 +89,9 @@ void main(){
 
         images = self.inputs["Image"].getValue();
 
-        # create hidden window
-        window = glutCreateWindow("")
-        glutHideWindow()
-
         results = []
         for image in images:
             results.append( self.render(image) )
-
-        # delete hidden window
-        glutDestroyWindow(window)
-        glutMainLoopEvent()
-        glutMainLoopEvent()
 
         self.outputs["Image"].setValue( results );
 

--- a/setup.py
+++ b/setup.py
@@ -20,15 +20,13 @@ setuptools.setup(
                 "cinemasci.smoke"
              ],
     install_requires=[
-        "setuptools>=60",
         "numpy",
         "scipy",
         "matplotlib",
-        "pytest",
         "py",
         "imageio",
         "ipywidgets",
-        "PyOpenGL"
+        "moderngl<6"
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/testing/CinemaRenderTest.py
+++ b/testing/CinemaRenderTest.py
@@ -1,38 +1,35 @@
-import unittest
+import pytest
+import pytest_xvfb
+
 import os
 import cinemasci
 
-class CinemaRenderTest(unittest.TestCase):
-    gold    = "testing/gold"
-    scratch = "testing/scratch"
+@pytest.fixture(autouse=True, scope='session')
+def ensure_xvfb():
+  if not pytest_xvfb.xvfb_available():
+    raise Exception("Tests need Xvfb to run.")
 
-    def __init__(self, *args, **kwargs):
-        super(CinemaRenderTest, self).__init__(*args, **kwargs)
+def test_render():
+   # create a test database
+  os.system("./bin/create-database --database scratch/cinema.cdb")
 
-    def setUp(self):
-        print("Running test: {}".format(self._testMethodName))
+  # open a cinema database
+  cdb = cinemasci.DatabaseReader();
+  cdb.inputs["Path"].setValue( 'scratch/cinema.cdb' );
 
-    def test_smoketest(self):
-        # create a test database
-        os.system("./bin/create-database --database scratch/cinema.cdb")
+  # Select Some Data Products\n",
+  query = cinemasci.DatabaseQuery();
+  query.inputs["Table"].setValue(cdb.outputs['Table']);
+  query.inputs["Query"].setValue('SELECT * FROM input LIMIT 5 OFFSET 0');
 
-        # open a cinema database
-        cdb  = cinemasci.DatabaseReader();
-        cdb.inputs["Path"].setValue( 'scratch/cinema.cdb' );
+  # Read Data Products
+  imageReader = cinemasci.ImageReader();
+  imageReader.inputs["Table"].setValue(query.outputs['Table'])
 
-        # Select Some Data Products\n",
-        query = cinemasci.DatabaseQuery();
-        query.inputs["Table"].setValue(cdb.outputs['Table']);
-        query.inputs["Query"].setValue('SELECT * FROM input LIMIT 5 OFFSET 0');
+  # Read Data Products
+  imageRenderer = cinemasci.ImageRenderer();
+  imageRenderer.inputs["Image"].setValue( imageReader.outputs["Images"] );
 
-        # Read Data Products
-        imageReader = cinemasci.ImageReader();
-        imageReader.inputs["Table"].setValue(query.outputs['Table'])
-
-        # Read Data Products
-        imageRenderer = cinemasci.ImageRenderer();
-        imageRenderer.inputs["Image"].setValue( imageReader.outputs["Images"] );
-
-        images = imageRenderer.outputs["Image"].getValue();
-        print(images)
-
+  # print images
+  images = imageRenderer.outputs["Image"].getValue();
+  print(images)


### PR DESCRIPTION
Hi David,
this PR changes the rendering backend from PyOpenGL to ModernGL. ModernGL drastically simplifies codes and better supports headless/offscreen rendering. However, to run the headless rendering tests we have to use `pytest` instead of `unittest`. I also think `pytest` is better than `unittest` in general.