### PR TITLE
OpenGL update; DemoCDB filter

### DIFF
--- a/cinemasci/DemoCDB.py
+++ b/cinemasci/DemoCDB.py
@@ -1,0 +1,216 @@
+from .Core import *
+
+import numpy as np
+import moderngl
+from PIL import Image
+
+class DemoCDB(Filter):
+    def __init__(self):
+        super().__init__()
+        self.addInputPort("Resolution", "vec2", (256,256))
+        self.addInputPort("PhiSamples", "vec3", (0,360,360))
+        self.addInputPort("ThetaSamples", "vec3", (20,20,1))
+        self.addInputPort("Time", "float", 0)
+        self.addOutputPort("Images", "List", [])
+
+        # create context
+        self.ctx = moderngl.create_standalone_context(require=330)
+
+        # fullscreen quad
+        self.quad = self.ctx.buffer(
+            np.array([
+                1.0,    1.0,
+                -1.0,    1.0,
+                -1.0, -1.0,
+                 1.0, -1.0,
+                 1.0,    1.0
+            ]).astype('f4').tobytes()
+        )
+
+        # program
+        self.program = self.ctx.program(
+            vertex_shader=self.getVertexShaderCode(),
+            fragment_shader=self.getFragmentShaderCode(),
+            varyings=["uv"]
+        )
+        self.vao = self.ctx.simple_vertex_array(self.program, self.quad, 'position')
+
+    def getVertexShaderCode(self):
+        return """
+#version 330
+
+in vec2 position;
+out vec2 uv;
+
+void main(){
+    uv = position;
+    gl_Position = vec4(position,0,1);
+}
+"""
+
+    def getFragmentShaderCode(self):
+        return """
+#version 330
+
+in vec2 uv;
+out vec3 fragColor;
+uniform vec2 iResolution;
+uniform float iTime;
+uniform float iPhi;
+uniform float iTheta;
+
+const int MAX_MARCHING_STEPS = 255;
+const float MIN_DIST = 0.1;
+const float MAX_DIST = 40.0;
+const float EPSILON = 0.001;
+
+float planeSDF(vec3 p) {
+    return abs(p.y);
+}
+
+float sphereSDF(vec3 p, float r) {
+    return length(p) - r;
+}
+
+vec2 compare(vec2 hit, float d, float id){
+  return hit.x<d ? hit : vec2(d,id);
+}
+
+vec2 sceneSDF(vec3 p) {
+    vec2 hit = vec2(planeSDF(p),0);
+    hit = compare(hit, sphereSDF(p-2.0*vec3(cos(iTime),0.25,sin(iTime)), 0.25), 1);
+    hit = compare(hit, sphereSDF(p-vec3(0,1,0),1), 2);
+    return hit;
+}
+
+vec3 march(vec3 ro, vec3 rd, float tmin, float tmax) {
+    vec3 hit = vec3(0,-1,tmin);
+    for (int i = 0; i < MAX_MARCHING_STEPS; i++) {
+        hit.xy = sceneSDF(ro + hit.z * rd);
+        if (hit.x < EPSILON) {
+            return hit;
+        }
+        hit.z += hit.x;
+        if (hit.z >= tmax) {
+            return hit;
+        }
+    }
+    return hit;
+}
+
+vec3 estimateNormal(vec3 p) {
+    return normalize(vec3(
+        sceneSDF(vec3(p.x + EPSILON, p.y, p.z)).x - sceneSDF(vec3(p.x - EPSILON, p.y, p.z)).x,
+        sceneSDF(vec3(p.x, p.y + EPSILON, p.z)).x - sceneSDF(vec3(p.x, p.y - EPSILON, p.z)).x,
+        sceneSDF(vec3(p.x, p.y, p.z    + EPSILON)).x - sceneSDF(vec3(p.x, p.y, p.z - EPSILON)).x
+    ));
+}
+
+vec3 phongBRDF(vec3 lightDir, vec3 rayDir, vec3 normal, vec3 diff, vec3 spec, float shininess) {
+  vec3 color = diff;
+  vec3 reflectDir = reflect(-lightDir, normal);
+  float specDot = max(dot(reflectDir, rayDir), 0.0);
+  color += pow(specDot, shininess) * spec;
+  return color;
+}
+
+float softshadow(vec3 ro, vec3 rd, float tmin, float tmax)
+{
+  float res = 1.0;
+  vec3 hit = vec3(0,-1,tmin);
+  for (int i = 0; i < 16; i++) {
+      hit.xy = sceneSDF(ro + hit.z * rd);
+      res = min( res, 8.0*hit.x/hit.z );
+      hit.z += hit.x;
+  }
+  return clamp( res, 0.0, 1.0 );
+}
+
+void main() {
+    vec2 fragCoord = (uv*0.5+0.5)*iResolution;
+    vec3 focal = normalize(vec3(
+        cos(iPhi)*sin(iTheta),
+        cos(iTheta),
+        sin(iPhi)*sin(iTheta)
+    ));
+
+    float aspect = iResolution.x/iResolution.y;
+    vec3 rayDir = -normalize(focal);
+    vec3 up = vec3(0,1,0);
+    vec3 right = normalize(cross(rayDir,up));
+    vec3 up2 = -normalize(cross(rayDir,right));
+
+    float scale = 2.0;
+    vec3 origin = 15.0*focal + aspect*right*uv.x*scale + up2*uv.y*scale;
+
+    vec3 hit = march(origin, rayDir, MIN_DIST, MAX_DIST);
+
+    if (hit.z > MAX_DIST - EPSILON) {
+        fragColor = vec3(0);
+        return;
+    }
+
+    // The closest point on the surface to the eyepoint along the view ray
+    vec3 p = origin + hit.z * rayDir;
+    vec3 lightDir = normalize(vec3(1,1,0));
+    vec3 normal = estimateNormal(p);
+
+    vec3 materialColor = hit.y > 1.5 ? vec3(0.8,0,0) : hit.y > 0.5 ? vec3(0,0.8,0) :  vec3(0.3 + 0.1*mod( floor(1.0*p.z) + floor(1.0*p.x), 2.0));
+
+    vec3 radiance = vec3(0);
+    float irradiance = max(dot(lightDir, normal), 0.0);
+    vec3 brdf = phongBRDF(lightDir, rayDir, normal, materialColor, vec3(1), 1000.0);
+    radiance += brdf * irradiance * vec3(1);
+    radiance *= softshadow(p, lightDir, MIN_DIST, MAX_DIST);
+
+    fragColor = pow(radiance, vec3(1.0 / 2.2) ); // gamma correction
+
+    //fragColor = color*(hit.z-MIN_DIST)/(MAX_DIST-MIN_DIST);
+    //fragColor = estimateNormal(p);
+}
+        """
+
+    def render(self,phi,theta):
+
+        res = self.inputs["Resolution"].getValue()
+        time = self.inputs["Time"].getValue()
+
+        # create framebuffer
+        fbo = self.ctx.simple_framebuffer(res)
+        fbo.use()
+        fbo.clear(0.0, 0.0, 0.0, 1.0)
+
+        # render
+        self.program['iResolution'].value = res
+        self.program['iTime'].value = time
+        self.program['iPhi'].value = phi
+        self.program['iTheta'].value = theta
+        self.vao.render(moderngl.TRIANGLE_STRIP)
+
+        # read pixels
+        image = Image.frombytes('RGB', fbo.size, fbo.read(), 'raw', 'RGB', 0, -1)
+
+        # release resources
+        fbo.release()
+
+        return image
+
+    def update(self):
+        super().update()
+
+        phiSamples = self.inputs["PhiSamples"].getValue();
+        thetaSamples = self.inputs["ThetaSamples"].getValue();
+
+        results = []
+        for theta in range(thetaSamples[0],thetaSamples[1]+[0,1][thetaSamples[0]==thetaSamples[1]],thetaSamples[2]):
+            for phi in range(phiSamples[0],phiSamples[1]+[0,1][phiSamples[0]==phiSamples[1]],phiSamples[2]):
+                results.append(
+                    self.render(
+                        phi/360.0*2.0*np.pi,
+                        (90-theta)/180.0*np.pi,
+                    )
+                )
+
+        self.outputs["Images"].setValue(results);
+
+        return 1;

--- a/cinemasci/ImageReader.py
+++ b/cinemasci/ImageReader.py
@@ -1,6 +1,6 @@
 from .Core import *
 
-import imageio
+from PIL import Image
 
 class ImageReader(Filter):
 
@@ -24,7 +24,7 @@ class ImageReader(Filter):
     images = [];
     for i in range(1, len(table)):
       path = table[i][fileColumnIdx]
-      images.append( imageio.v2.imread(path) )
+      images.append( Image.open(path) )
 
     self.outputs["Images"].setValue(images)
 

--- a/cinemasci/ImageRenderer.py
+++ b/cinemasci/ImageRenderer.py
@@ -5,95 +5,94 @@ import moderngl
 from PIL import Image
 
 class ImageRenderer(Filter):
-  def __init__(self):
-    super(ImageRenderer, self).__init__()
-    self.addInputPort("Image", "List", [])
-    self.addOutputPort("Image", "List", [])
+    def __init__(self):
+        super().__init__()
+        self.addInputPort("Image", "List", [])
+        self.addOutputPort("Image", "List", [])
 
-    # create context
-    self.ctx = moderngl.create_standalone_context()
+        # create context
+        self.ctx = moderngl.create_standalone_context(require=330)
 
-    # fullscreen quad
-    vertices = np.array([
-      1.0,  1.0,
-      -1.0,  1.0,
-      -1.0, -1.0,
-      -1.0, -1.0,
-       1.0, -1.0,
-       1.0,  1.0
-    ])
-    self.quad = self.ctx.buffer(vertices.astype('f4').tobytes())
+        # fullscreen quad
+        self.quad = self.ctx.buffer(
+            np.array([
+                 1.0,  1.0,
+                -1.0,  1.0,
+                -1.0, -1.0,
+                 1.0, -1.0,
+                 1.0,  1.0
+            ]).astype('f4').tobytes()
+        )
 
-    # program
-    self.program = self.ctx.program(
-      vertex_shader=self.getVertexShaderCode(),
-      fragment_shader=self.getFragmentShaderCode(),
-      varyings=["vUV"]
-    )
-    self.program['tex'] = 0
+        # program
+        self.program = self.ctx.program(
+            vertex_shader=self.getVertexShaderCode(),
+            fragment_shader=self.getFragmentShaderCode(),
+            varyings=["uv"]
+        )
+        self.program['tex'] = 0
 
-    self.vao = self.ctx.simple_vertex_array(self.program, self.quad, 'position')
+        self.vao = self.ctx.simple_vertex_array(self.program, self.quad, 'position')
 
-  def getVertexShaderCode(self):
-    return """
-#version 120
+    def getVertexShaderCode(self):
+        return """
+#version 330
 
-attribute vec2 position;
-varying vec2 vUV;
+in vec2 position;
+out vec2 uv;
 
 void main(){
-  vUV = position/2. + vec2(0.5);
-  vUV.y = -vUV.y;
-  gl_Position = vec4(position,0,1);
+    uv = position/2.0+0.5;
+    uv.y *= -1.0;
+    gl_Position = vec4(position,0,1);
 }
-    """
+"""
 
-  def getFragmentShaderCode(self):
-    return """
-#version 120
+    def getFragmentShaderCode(self):
+        return """
+#version 330
 
 uniform sampler2D tex;
 
-varying vec2 vUV;
+in vec2 uv;
+out vec3 color;
 
 void main(){
-  vec4 c = texture2D(tex,vUV);
-  gl_FragColor = vec4(vec3(0.299*c.r + 0.587*c.g + 0.114*c.b),1);
-  // gl_FragColor = c;
-  // gl_FragColor = vec4(vUV.xy,0,1);
+    vec4 c = texture(tex,uv);
+    color = vec3(0.299*c.r + 0.587*c.g + 0.114*c.b);
 }
-    """
+"""
 
-  def render(self,image):
+    def render(self,image):
 
-    # create texture
-    texture = self.ctx.texture(image.shape[1::-1], image.shape[2], image)
-    texture.use(location=0)
+        # create texture
+        texture = self.ctx.texture(image.size, len(image.mode), image.tobytes(), alignment=4)
+        texture.use(location=0)
 
-    # create framebuffer
-    fbo = self.ctx.simple_framebuffer((image.shape[1], image.shape[0]))
-    fbo.use()
-    fbo.clear(0.0, 0.0, 0.0, 1.0)
-    self.vao.render(moderngl.TRIANGLE_STRIP)
+        # create framebuffer
+        fbo = self.ctx.simple_framebuffer(image.size)
+        fbo.use()
+        fbo.clear(0.0, 0.0, 0.0, 1.0)
+        self.vao.render(moderngl.TRIANGLE_STRIP)
 
-    # read pixels
-    image = Image.frombytes('RGB', fbo.size, fbo.read(), 'raw', 'RGB', 0, -1)
+        # read pixels
+        image = Image.frombytes('RGB', fbo.size, fbo.read(), 'raw', 'RGB', 0, -1)
 
-    # release resources
-    texture.release()
-    fbo.release()
+        # release resources
+        texture.release()
+        fbo.release()
 
-    return image
+        return image
 
-  def update(self):
-    super().update()
+    def update(self):
+        super().update()
 
-    images = self.inputs["Image"].getValue();
+        images = self.inputs["Image"].getValue();
 
-    results = []
-    for image in images:
-      results.append( self.render(image) )
+        results = []
+        for image in images:
+            results.append( self.render(image) )
 
-    self.outputs["Image"].setValue(results);
+        self.outputs["Image"].setValue(results);
 
-    return 1;
+        return 1;

--- a/cinemasci/__init__.py
+++ b/cinemasci/__init__.py
@@ -8,6 +8,7 @@ from .ImageRenderer import *
 from .ArtifactSource import *
 from .CinemaArtifactSource import *
 from .TestImageArtifactSource import *
+from .DemoCDB import *
 
 #
 # new factory function

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         "scipy",
         "matplotlib",
         "py",
-        "imageio",
+        "Pillow",
         "ipywidgets",
         "moderngl<6"
     ],


### PR DESCRIPTION
Hi David,
this PR updates the OpenGL implementation which works on two of my machines and on GitHub. If it is still not working on your machine then this must be a MacOS issue. If it is not working, I can try to create a MacOS GitHub action and see if I get it to run there.

This PR also adds a new DemoCDB filter which can create a CDB on the fly that consists of RGB images (in the future this filter will also be able to provide demo depth and scalar images). Here is a usage scenario:
```
demo = cinemasci.DemoCDB()
demo.inputs["Resolution"].setValue((256,256),False)
demo.inputs["PhiSamples"].setValue((0,360,45),False)
demo.inputs["ThetaSamples"].setValue((0,0,45),False)
demo.inputs["Time"].setValue(4)

images = demo.outputs["Images"].getValue();
for i in images:
    display(i)
```
As you can see you can specify the image resolution and the number of phi-theta samples in the form of `(min angle, max angle, angle step)`. The depicted scene is also time dependent. Under the hood the filter uses distance ray marching to render an implicit scene (the scene is defined mathematically via distance functions and not via list of triangles).

