### PR TITLE
new port syntax; improved widget response

### DIFF
--- a/cinema
+++ b/cinema
@@ -60,8 +60,8 @@ with open(f'{args.database}/data.csv', 'w') as dbinfo:
             im_name = f'{cur_image:03}.jpg'
 
             # provide input parameters and save the resulting images
-            artifactSource.inputs["Parameters"].setValue( {'phi': p, 'theta': t} );
-            images = artifactSource.outputs["Artifacts"].getValue();
+            artifactSource.inputs.Parameters.set( {'phi': p, 'theta': t} );
+            images = artifactSource.outputs.Artifacts.get();
             for i in images:
                 i.save(os.path.join(args.database, im_name))
                 cur_image += 1

--- a/cinemasci/ArtifactSource.py
+++ b/cinemasci/ArtifactSource.py
@@ -12,15 +12,15 @@ class ArtifactSource(Filter):
     def update(self):
         super().update()
 
-        kwargs = self.inputs["Parameters"].getValue()
+        kwargs = self.inputs.Parameters.get()
 
         artifacts = self.generate_artifacts(**kwargs)
-    
-        self.outputs["Artifacts"].setValue(artifacts)
+
+        self.outputs.Artifacts.set(artifacts)
 
         return 1;
 
-    # generate the artifacts 
+    # generate the artifacts
     def generate_artifacts(self, **kwargs):
         # must be overridden by subclasses
         return []

--- a/cinemasci/CinemaArtifactSource.py
+++ b/cinemasci/CinemaArtifactSource.py
@@ -19,7 +19,7 @@ class CinemaArtifactSource(ArtifactSource):
         self.addInputPort("Parameters", "Dictionary", [])
         self.addOutputPort("Artifacts", "List", [])
 
-        # instance variables 
+        # instance variables
         self.cdb = CinemaDatabaseReader();
         self.query = DatabaseQuery();
         self.imageReader = ImageReader();
@@ -30,20 +30,20 @@ class CinemaArtifactSource(ArtifactSource):
     #
     @property
     def path(self):
-        return self.cdb.inputs["Path"].getValue(); 
+        return self.cdb.inputs.Path.get();
 
     @path.setter
     def path(self, value):
-        self.cdb.inputs["Path"].setValue( value );
+        self.cdb.inputs.Path.set( value );
 
     #
-    # generate artifacts 
+    # generate artifacts
     #
     def generate_artifacts(self, **kwargs):
         # do the query
-        self.query.inputs["Table"].setValue(self.cdb.outputs['Table']);
-        self.query.inputs["Query"].setValue('SELECT * FROM input LIMIT 5 OFFSET 0');
-        self.imageReader.inputs["Table"].setValue(self.query.outputs['Table'])
-        # self.imageRenderer.inputs["Artifacts"].setValue( self.imageReader.outputs["Images"] );
+        self.query.inputs.Table.set(self.cdb.outputs.Table);
+        self.query.inputs.Query.set('SELECT * FROM input LIMIT 5 OFFSET 0');
+        self.imageReader.inputs.Table.set(self.query.outputs.Table)
+        # self.imageRenderer.inputs.Artifacts.set( self.imageReader.outputs.Images );
 
-        return self.imageReader.outputs["Images"]
+        return self.imageReader.outputs.Images

--- a/cinemasci/CinemaDatabaseReader.py
+++ b/cinemasci/CinemaDatabaseReader.py
@@ -14,7 +14,7 @@ class CinemaDatabaseReader(Filter):
     super().update()
 
     table = [];
-    dbPath = self.inputs["Path"].getValue();
+    dbPath = self.inputs.Path.get();
     dataCsvPath = dbPath + '/data.csv';
     with open(dataCsvPath, 'r+') as csvfile:
       spamreader = csv.reader(csvfile, delimiter=',')
@@ -25,10 +25,10 @@ class CinemaDatabaseReader(Filter):
     table = list(filter(lambda row: len(row)>0, table))
 
     # add dbPath prefix to file column
-    fileColumnIdx = table[0].index( self.inputs["FileColumn"].getValue() );
+    fileColumnIdx = table[0].index( self.inputs.FileColumn.get() );
     for i in range(1,len(table)):
       table[i][fileColumnIdx] = dbPath + '/' + table[i][fileColumnIdx];
 
-    self.outputs["Table"].setValue(table);
+    self.outputs.Table.set(table);
 
     return 1;

--- a/cinemasci/Core.py
+++ b/cinemasci/Core.py
@@ -6,12 +6,12 @@ class Port():
         self._listeners = []
         self._value = value
 
-    def getValue(self):
+    def get(self):
         if isinstance(self._value, Port):
-            return self._value.getValue()
+            return self._value.get()
         return self._value;
 
-    def setValue(self, value, update = True):
+    def set(self, value, update = True):
         # if old value is a port stop listing for push events
         if isinstance(self._value, Port):
             self._value._listeners.remove(self)
@@ -32,16 +32,22 @@ class Port():
             for listener in self._listeners:
                 listener.parent.update()
 
+class PortList():
+    def __init__(self):
+        return
+
 class Filter():
     def __init__(self):
-        self.inputs = {}
-        self.outputs = {}
+        self.inputs = PortList()
+        self.outputs = PortList()
 
     def addInputPort(self, name, type, value):
-        self.inputs[name] = Port(type, value, self, True)
+        setattr(self.inputs, name, Port(type, value, self, True))
+        # self.inputs[name] = Port(type, value, self, True)
 
     def addOutputPort(self, name, type, value):
-        self.outputs[name] = Port(type, value, self)
+        setattr(self.outputs, name, Port(type, value, self))
+        # self.outputs[name] = Port(type, value, self)
 
     def update(self):
         # print("-> "+type(self).__name__)

--- a/cinemasci/DatabaseQuery.py
+++ b/cinemasci/DatabaseQuery.py
@@ -66,13 +66,13 @@ class DatabaseQuery(Filter):
 
     db = sqlite3.connect(":memory:");
 
-    table = self.inputs["Table"].getValue();
+    table = self.inputs.Table.get();
 
     self.createTable(db, table);
     self.insertData(db, table);
 
-    output = self.queryData(db, self.inputs["Query"].getValue());
+    output = self.queryData(db, self.inputs.Query.get());
 
-    self.outputs["Table"].setValue(output);
+    self.outputs.Table.set(output);
 
     return 1;

--- a/cinemasci/DemoCDB.py
+++ b/cinemasci/DemoCDB.py
@@ -172,8 +172,8 @@ void main() {
 
     def render(self,phi,theta):
 
-        res = self.inputs["Resolution"].getValue()
-        time = self.inputs["Time"].getValue()
+        res = self.inputs.Resolution.get()
+        time = self.inputs.Time.get()
 
         # create framebuffer
         fbo = self.ctx.simple_framebuffer(res)
@@ -198,8 +198,8 @@ void main() {
     def update(self):
         super().update()
 
-        phiSamples = self.inputs["PhiSamples"].getValue();
-        thetaSamples = self.inputs["ThetaSamples"].getValue();
+        phiSamples = self.inputs.PhiSamples.get();
+        thetaSamples = self.inputs.ThetaSamples.get();
 
         results = []
         for theta in range(thetaSamples[0],thetaSamples[1]+[0,1][thetaSamples[0]==thetaSamples[1]],thetaSamples[2]):
@@ -213,6 +213,6 @@ void main() {
 
         # self.ctx.release()
 
-        self.outputs["Images"].setValue(results);
+        self.outputs.Images.set(results);
 
         return 1;

--- a/cinemasci/ImageReader.py
+++ b/cinemasci/ImageReader.py
@@ -13,8 +13,8 @@ class ImageReader(Filter):
   def update(self):
     super().update()
 
-    table = self.inputs["Table"].getValue()
-    fileColumn = self.inputs["FileColumn"].getValue()
+    table = self.inputs.Table.get()
+    fileColumn = self.inputs.FileColumn.get()
 
     try:
       fileColumnIdx = table[0].index(fileColumn)
@@ -26,6 +26,6 @@ class ImageReader(Filter):
       path = table[i][fileColumnIdx]
       images.append( Image.open(path) )
 
-    self.outputs["Images"].setValue(images)
+    self.outputs.Images.set(images)
 
     return 1;

--- a/cinemasci/ImageRenderer.py
+++ b/cinemasci/ImageRenderer.py
@@ -7,8 +7,8 @@ from PIL import Image
 class ImageRenderer(Filter):
     def __init__(self):
         super().__init__()
-        self.addInputPort("Image", "List", [])
-        self.addOutputPort("Image", "List", [])
+        self.addInputPort("Images", "List", [])
+        self.addOutputPort("Images", "List", [])
 
         # create context
         self.ctx = moderngl.create_standalone_context(require=330)
@@ -88,12 +88,12 @@ void main(){
     def update(self):
         super().update()
 
-        images = self.inputs["Image"].getValue();
+        images = self.inputs.Images.get()
 
         results = []
         for image in images:
             results.append( self.render(image) )
 
-        self.outputs["Image"].setValue(results);
+        self.outputs.Images.set(results)
 
-        return 1;
+        return 1

--- a/cinemasci/ImageUI.py
+++ b/cinemasci/ImageUI.py
@@ -4,6 +4,8 @@ from ipywidgets import interact, widgets
 from IPython import display
 import matplotlib.pyplot as plt
 
+import math
+
 class ImageUI(Filter):
 
     def __init__(self):
@@ -11,36 +13,32 @@ class ImageUI(Filter):
 
         self.addInputPort("Images", "List", [])
 
-        self.fig = plt.figure()
-        self.fig.set_size_inches(10,10)
-        plt.close(self.fig)
-
-        self.plots = []
-        self.hdisplay = None
         self.nImages = -1
 
-    def show(self):
-        self.hdisplay = display.display('', display_id=True)
-        self.update()
+        plt.ioff()
+        self.fig = plt.figure()
 
     def update(self):
         super().update()
 
-        images = self.inputs['Images'].getValue()
+        images = self.inputs.Images.get()
         nImages = len(images)
 
         if self.nImages != nImages:
             self.nImages = nImages
             self.fig.clear()
             self.plots = []
-            for i in range(0,nImages):
-                self.plots.append( self.fig.add_subplot(1, self.nImages, i+1) )
+            dim = math.ceil(math.sqrt(self.nImages))
+            for i,image in enumerate(images):
+                axis = self.fig.add_subplot(dim, dim, i+1)
+                axis.set_axis_off()
+                im = axis.imshow(image)
+                self.plots.append( [axis,im] )
 
-        for i in range(0,self.nImages):
-            self.plots[i].imshow(images[i])
+        for i,image in enumerate(images):
+            self.plots[i][1].set_data(image)
 
-        if self.hdisplay != None:
-            self.hdisplay.update(self.fig)
+        self.fig.canvas.draw()
 
 
         return 1

--- a/cinemasci/ParameterWidgets.py
+++ b/cinemasci/ParameterWidgets.py
@@ -12,7 +12,7 @@ class ParameterWidgets(Filter):
 
     def generateWidgets(self):
 
-        table = self.inputs["Table"].getValue()
+        table = self.inputs.Table.get()
         header = table[0]
         self.widgets = []
 
@@ -45,7 +45,7 @@ class ParameterWidgets(Filter):
     def update(self):
         super().update()
 
-        table = self.inputs["Table"].getValue()
+        table = self.inputs.Table.get()
         header = table[0]
 
         sql = 'SELECT * FROM input WHERE '
@@ -66,6 +66,6 @@ class ParameterWidgets(Filter):
         if len(self.widgets) > 0:
             sql = sql[:-5]
 
-        self.outputs["SQL"].setValue(sql)
+        self.outputs.SQL.set(sql)
 
         return 1

--- a/testing/CinemaArtifactSource.py
+++ b/testing/CinemaArtifactSource.py
@@ -19,7 +19,7 @@ def setUp():
             pass
 
 
-def compare( a, b ): 
+def compare( a, b ):
     # '25' is a tolerance value, to be replaced when images can be inspected
     results = compare_images( a, b, 25 )
 
@@ -35,16 +35,16 @@ def test_artifact_source():
     artifactSource = cinemasci.TestImageArtifactSource();
 
     # provide input parameters and save the resulting images
-    artifactSource.inputs["Parameters"].setValue( {'phi': 25.5, 'theta': 50.0} );
-    images = artifactSource.outputs["Artifacts"].getValue();
+    artifactSource.inputs.Parameters.set( {'phi': 25.5, 'theta': 50.0} );
+    images = artifactSource.outputs.Artifacts.get();
     for i in images:
         i.save(os.path.join(scratch, "artifact", "imagesource.png"))
 
     # check the results
-    resdir = os.path.join(gold, "artifact", "imagesource.png" ) 
+    resdir = os.path.join(gold, "artifact", "imagesource.png" )
     scratch = os.path.join(scratch, "artifact", "imagesource.png" )
     assert os.path.exists(scratch)
-    result = compare( resdir, scratch ) 
+    result = compare( resdir, scratch )
     assert result
 
 def test_cinema_artifact_source():
@@ -55,5 +55,5 @@ def test_cinema_artifact_source():
     # create an artifact source
     artifactSource = cinemasci.CinemaArtifactSource()
     # point it to a database
-    artifactSource.path = os.path.join(gold, "artifact", "cinema.cdb") 
-    artifactSource.inputs["Parameters"].setValue( {'phi': 10.0, 'theta': 110.0} );
+    artifactSource.path = os.path.join(gold, "artifact", "cinema.cdb")
+    artifactSource.inputs.Parameters.set( {'phi': 10.0, 'theta': 110.0} );

--- a/testing/CinemaRenderTest.py
+++ b/testing/CinemaRenderTest.py
@@ -25,21 +25,21 @@ def test_render():
 
   # open a cinema database
   cdb = cinemasci.CinemaDatabaseReader();
-  cdb.inputs["Path"].setValue( cdbpath );
+  cdb.inputs.Path.set( cdbpath );
 
   # Select Some Data Products\n",
   query = cinemasci.DatabaseQuery();
-  query.inputs["Table"].setValue(cdb.outputs['Table']);
-  query.inputs["Query"].setValue('SELECT * FROM input LIMIT 5 OFFSET 0');
+  query.inputs.Table.set(cdb.outputs.Table);
+  query.inputs.Query.set('SELECT * FROM input LIMIT 5 OFFSET 0');
 
   # Read Data Products
   imageReader = cinemasci.ImageReader();
-  imageReader.inputs["Table"].setValue(query.outputs['Table'])
+  imageReader.inputs.Table.set(query.outputs.Table)
 
-  # Read Data Products
+  # Render Data Products
   imageRenderer = cinemasci.ImageRenderer();
-  imageRenderer.inputs["Image"].setValue( imageReader.outputs["Images"] );
+  imageRenderer.inputs.Images.set( imageReader.outputs.Images );
 
   # print images
-  images = imageRenderer.outputs["Image"].getValue();
+  images = imageRenderer.outputs.Images.get();
   print(images)


### PR DESCRIPTION
Hi David,
this PR overhauls the input/output port syntax that supports python introspection/autocompletion. So the following old code:
```
renderer.inputs["Images"].setValue( reader.outputs["Images"] )
renderer.outputs["Images"].getValue()
```
now reads as
```
renderer.inputs.Images.set( reader.outputs.Images )
renderer.outputs.Images.get()
```
This is also shorter and nicer to work with. The PR also updates the ImageUI filter to improve performance between the python-server and the notebook-client. Give it a try with your own database and check how fast it is:
```
# This matplotlib magic function is crucial to get better server-client performance
%matplotlib notebook

import cinemasci

# open a cinema database
cdb = cinemasci.CinemaDatabaseReader();
cdb.inputs.Path.set( '/home/jones/external/data/ttk-data/DragonImages.cdb' )

# create widgets
pw = cinemasci.ParameterWidgets();
pw.inputs.Table.set(cdb.outputs.Table)

# query data products
query = cinemasci.DatabaseQuery();
query.inputs.Table.set(cdb.outputs.Table,False);
query.inputs.Query.set(pw.outputs.SQL);

# read data products
imageReader = cinemasci.ImageReader();
imageReader.inputs.Table.set(query.outputs.Table)

# render data products
imageRenderer = cinemasci.ImageRenderer();
imageRenderer.inputs.Images.set( imageReader.outputs.Images );

imageRenderer2 = cinemasci.ImageRenderer();
imageRenderer2.inputs.Images.set( imageRenderer.outputs.Images );

# create output viewport
imageUI = cinemasci.ImageUI()
imageUI.inputs.Images.set( imageRenderer2.outputs.Images )

# build UI
import ipywidgets as widgets
display(imageUI.fig)
widgets.HBox(pw.widgets)
```
