### PR TITLE
Switch to CinemaSci Image Class

### DIFF
--- a/cinemasci/Annotation.py
+++ b/cinemasci/Annotation.py
@@ -1,0 +1,80 @@
+from .Core import *
+import PIL
+import numpy
+import sys
+
+class Annotation(Filter):
+
+    def __init__(self):
+        super().__init__()
+
+        self.addInputPort("XY", "Tuple", (20,20))
+        self.addInputPort("Size", "Int", 20)
+        self.addInputPort("Spacing", "Int", 0)
+        self.addInputPort("Color", "Tuple", (0,0,0))
+        self.addInputPort("Images", "List", [])
+        self.addInputPort("Ignore", "List", ['FILE'])
+        self.addOutputPort("Images", "List", [])
+
+    #
+    # solution from:
+    # https://www.programcreek.com/python/?CodeExample=get+font
+    #
+    def __get_font(self, size):
+        """Attempts to retrieve a reasonably-looking TTF font from the system.
+
+        We don't make much of an effort, but it's what we can reasonably do without
+        incorporating additional dependencies for this task.
+        """
+        if sys.platform == 'win32':
+            font_names = ['Arial']
+        elif sys.platform in ['linux', 'linux2']:
+            font_names = ['DejaVuSans-Bold', 'DroidSans-Bold']
+        elif sys.platform == 'darwin':
+            font_names = ['Menlo', 'Helvetica']
+
+        font = None
+        for font_name in font_names:
+            try:
+                font = PIL.ImageFont.truetype(font_name, size)
+                break
+            except IOError:
+                continue
+
+        return font
+
+    def update(self):
+        super().update()
+
+        images = self.inputs.Images.get()
+        nImages = len(images)
+
+        font = self.__get_font(self.inputs.Size.get())
+
+        result = []
+        ignoreList = list(map(str.lower, self.inputs.Ignore.get()))
+
+        for image in images:
+            rgbImage = PIL.Image.fromarray( image.channel["RGB"] )
+            text = ''
+            for t in image.meta:
+                if t.lower() in ignoreList:
+                    continue
+                text = text + ' ' + t+': '+str(image.meta[t]) + '\n'
+
+            I1 = PIL.ImageDraw.Draw(rgbImage)
+            I1.multiline_text(
+                self.inputs.XY.get(),
+                text,
+                fill=self.inputs.Color.get(),
+                font=font,
+                spacing=self.inputs.Spacing.get()
+            )
+
+            outImage = image.copy()
+            outImage.channel['RGB'] = numpy.array(rgbImage)
+            result.append( outImage )
+
+        self.outputs.Images.set(result)
+
+        return 1

--- a/cinemasci/Core.py
+++ b/cinemasci/Core.py
@@ -1,7 +1,24 @@
 class Image():
-    def __init__(self):
-        self.origin = (0,0)
-        self.channels = {}
+    def __init__(self, channel={}, meta={}, origin=(0,0)):
+        self.origin = origin
+        self.channel = channel
+        self.meta = meta
+
+    def copy(self):
+        return Image(
+            self.channel.copy(),
+            self.meta.copy(),
+            self.origin
+        )
+
+    @property
+    def shape(self):
+        if self.channel.size<1:
+            return (0,0,0)
+
+        # get first channel
+        for c in self.channel:
+            return self.channel[c].shape
 
 class Port():
     def __init__(self, type, value, parent, isInput = False):

--- a/cinemasci/Core.py
+++ b/cinemasci/Core.py
@@ -1,3 +1,8 @@
+class Image():
+    def __init__(self):
+        self.origin = (0,0)
+        self.channels = {}
+
 class Port():
     def __init__(self, type, value, parent, isInput = False):
         self.type = type

--- a/cinemasci/ImageReader.py
+++ b/cinemasci/ImageReader.py
@@ -1,35 +1,39 @@
 from .Core import *
 
 import PIL
+import numpy
 
 class ImageReader(Filter):
 
-  def __init__(self):
-    super(ImageReader, self).__init__()
-    self.addInputPort("Table", "Table", [])
-    self.addInputPort("FileColumn", "String", "FILE")
-    self.addOutputPort("Images", "List", [])
+    def __init__(self):
+        super(ImageReader, self).__init__()
+        self.addInputPort("Table", "Table", [])
+        self.addInputPort("FileColumn", "String", "FILE")
+        self.addOutputPort("Images", "List", [])
 
-  def update(self):
-    super().update()
+    def update(self):
+        super().update()
 
-    table = self.inputs.Table.get()
-    fileColumn = self.inputs.FileColumn.get()
+        table = self.inputs.Table.get()
+        fileColumn = self.inputs.FileColumn.get()
 
-    try:
-      fileColumnIdx = table[0].index(fileColumn)
-    except ValueError as e:
-      return print("Table does not contain '" + fileColumn + "' column!")
+        try:
+            fileColumnIdx = list(map(str.lower,table[0])).index(fileColumn.lower())
+        except ValueError as e:
+            return print("Table does not contain '" + fileColumn + "' column!")
 
-    images = [];
-    for i in range(1, len(table)):
-      path = table[i][fileColumnIdx]
-      data = PIL.Image.open(path)
-      # image = cinemasci.Image()
-      # image.channels["RGB"] = data
-      # images.append( image )
-      images.append( data )
+        images = [];
+        for i in range(1, len(table)):
+            row = table[i]
+            path = row[fileColumnIdx]
+            rawImage = PIL.Image.open(path)
 
-    self.outputs.Images.set(images)
+            image = Image({ 'RGB': numpy.asarray(rawImage) })
+            for j in range(0, len(row)):
+                image.meta[table[0][j]] = row[j]
 
-    return 1;
+            images.append( image )
+
+        self.outputs.Images.set(images)
+
+        return 1;

--- a/cinemasci/ImageReader.py
+++ b/cinemasci/ImageReader.py
@@ -1,6 +1,6 @@
 from .Core import *
 
-from PIL import Image
+import PIL
 
 class ImageReader(Filter):
 
@@ -24,7 +24,11 @@ class ImageReader(Filter):
     images = [];
     for i in range(1, len(table)):
       path = table[i][fileColumnIdx]
-      images.append( Image.open(path) )
+      data = PIL.Image.open(path)
+      # image = cinemasci.Image()
+      # image.channels["RGB"] = data
+      # images.append( image )
+      images.append( data )
 
     self.outputs.Images.set(images)
 

--- a/cinemasci/ImageRenderer.py
+++ b/cinemasci/ImageRenderer.py
@@ -67,7 +67,7 @@ void main(){
     def render(self,image):
 
         # create texture
-        texture = self.ctx.texture(image.size, len(image.mode), image.tobytes(), alignment=4)
+        texture = self.ctx.texture(image.size, len(image.mode), image.tobytes(), alignment=1)
         texture.use(location=0)
 
         # create framebuffer

--- a/cinemasci/__init__.py
+++ b/cinemasci/__init__.py
@@ -11,6 +11,7 @@ from .TestImageArtifactSource import *
 from .DemoCDB import *
 from .ImageUI import *
 from .ParameterWidgets import *
+from .Annotation import *
 
 #
 # new factory function


### PR DESCRIPTION
This PR introduces the cinemasci `Image` class in `Core.py`. In short, image objects in cinemasci have three properties that set them aside from image formats present in other python libraries:
1. Origin: this tuple specifies the xy pixel offset of the current image during compositing into a final viewport
2. Channel: a dictionary that records different pixel values (e.g., rgb, depth, scalar values, ...) that are stored as numpy arrays 
3. Meta: a dictionary that records meta information of the image (e.g., the associated timestep, camera angle, ...)

Here is an example:
```
import cinemasci
import numpy

# create 3x3 pixel image with an rgb and a scalar channel
image = cinemasci.Image()
image.channel['RGB'] = numpy.array(
    [
        255,0,0,  255,0,0,  255,0,0, # three pixels of the first row (each pixel has an rgb value)
        0,255,0,  0,255,0,  0,255,0, # three pixels of the second row
        0,0,255,  0,0,255,  0,0,255  # three pixels of the third row
    ],
    dtype=numpy.uint8 # data type of the pixels are 8bit unsigned integers
).reshape( (3,3,3) )  # 3x3 pixels with 3 values for each pixel

image.channel['SomeScalar'] = numpy.array(
    [
        0.0, 0.0, 1.0, # three pixels of the first row (each pixel has one scalar value)
        0.0, 0.5, 1.0, # three pixels of the second row
        0.0, 0.0, 1.0  # three pixels of the third row
    ],
    dtype=numpy.float32 # data type of the pixels are 32bit floats
).reshape( (3,3,1) )    # 3x3 pixels with one value for each pixel

# display channels
from matplotlib import pyplot
fig = pyplot.figure()
fig.add_subplot(1, 2, 1)
pyplot.imshow(image.channel['RGB'])
fig.add_subplot(1, 2, 2)
pyplot.imshow(image.channel['SomeScalar'], interpolation='nearest', cmap='gray')
```
![image](https://user-images.githubusercontent.com/24282273/170894425-2f1d9470-1d0c-4229-be71-d8e9aa8f1d44.png)


This PR also adds a new filter called `Annotation` which adds the meta information of an image to its RGB channel. Here is an example:
```
import cinemasci
demo = cinemasci.DemoCDB()
demo.inputs.Resolution.set((512,512),False)
demo.inputs.PhiSamples.set((45,360,45),False)
demo.inputs.ThetaSamples.set((20,20,45),False)
demo.inputs.Time.set(0.5)

annotation = cinemasci.Annotation()
annotation.inputs.Color.set( (255,255,255), False )
annotation.inputs.Size.set( 30, False )
annotation.inputs.XY.set( (0,0), False )
annotation.inputs.Spacing.set( 20, False )
annotation.inputs.Images.set( demo.outputs.Images )

import PIL
images = annotation.outputs.Images.get();
for i in images:
    display(PIL.Image.fromarray(i.channel['RGB']))
```
![image](https://user-images.githubusercontent.com/24282273/170894411-0787cf95-252f-4791-a6c9-b4644f72ebb5.png)

