### PR TITLE
HDF5 support

### DIFF
--- a/cinemasci/CinemaDatabaseReader.py
+++ b/cinemasci/CinemaDatabaseReader.py
@@ -17,9 +17,9 @@ class CinemaDatabaseReader(Filter):
     dbPath = self.inputs.Path.get();
     dataCsvPath = dbPath + '/data.csv';
     with open(dataCsvPath, 'r+') as csvfile:
-      spamreader = csv.reader(csvfile, delimiter=',')
-      for row in spamreader:
-        table.append(row)
+        rows = csv.reader(csvfile, delimiter=',')
+        for row in rows:
+            table.append(row)
 
     # remove empty lines
     table = list(filter(lambda row: len(row)>0, table))
@@ -27,7 +27,7 @@ class CinemaDatabaseReader(Filter):
     # add dbPath prefix to file column
     fileColumnIdx = table[0].index( self.inputs.FileColumn.get() );
     for i in range(1,len(table)):
-      table[i][fileColumnIdx] = dbPath + '/' + table[i][fileColumnIdx];
+        table[i][fileColumnIdx] = dbPath + '/' + table[i][fileColumnIdx];
 
     self.outputs.Table.set(table);
 

--- a/cinemasci/Core.py
+++ b/cinemasci/Core.py
@@ -1,8 +1,8 @@
 class Image():
-    def __init__(self, channel={}, meta={}, origin=(0,0)):
+    def __init__(self, channel=None, meta=None, origin=(0,0)):
         self.origin = origin
-        self.channel = channel
-        self.meta = meta
+        self.channel = channel or {}
+        self.meta = meta or {}
 
     def copy(self):
         return Image(

--- a/cinemasci/ImageReader.py
+++ b/cinemasci/ImageReader.py
@@ -2,11 +2,13 @@ from .Core import *
 
 import PIL
 import numpy
+import h5py
+import os
 
 class ImageReader(Filter):
 
     def __init__(self):
-        super(ImageReader, self).__init__()
+        super().__init__()
         self.addInputPort("Table", [])
         self.addInputPort("FileColumn", "FILE")
         self.addOutputPort("Images", [])
@@ -26,16 +28,39 @@ class ImageReader(Filter):
         for i in range(1, len(table)):
             row = table[i]
             path = row[fileColumnIdx]
-            rawImage = PIL.Image.open(path)
-            if rawImage.mode == 'RGB':
-                rawImage.putalpha(1)
 
-            image = Image({ 'RGBA': numpy.asarray(rawImage) })
-            for j in range(0, len(row)):
-                image.meta[table[0][j]] = row[j]
+            filename, extension = os.path.splitext(path)
+            extension = str.lower(extension[1:])
+
+            image = None
+            if extension == 'h5':
+                image = Image()
+                file = h5py.File(path, 'r')
+
+                image.origin = numpy.array(file.get('origin'))
+                for (g,v) in [('channel',image.channel), ('meta',image.meta)]:
+                    group = file.get(g)
+                    if group==None:
+                        raise ValueError('h5 file not formatted correctly')
+                    for k in group.keys():
+                        v[k] = numpy.array(group.get(k))
+
+                file.close()
+
+            elif str.lower(extension) in ['png','jpg','jpeg']:
+                rawImage = PIL.Image.open(path)
+                if rawImage.mode == 'RGB':
+                    rawImage.putalpha(1)
+
+                image = Image({ 'RGBA': numpy.asarray(rawImage) })
+                for j in range(0, len(row)):
+                    image.meta[table[0][j]] = row[j]
+
+            else:
+                raise ValueError('Unable to read image: '+path)
 
             images.append( image )
 
         self.outputs.Images.set(images)
 
-        return 1;
+        return 1

--- a/cinemasci/ImageWriter.py
+++ b/cinemasci/ImageWriter.py
@@ -1,0 +1,127 @@
+from .Core import *
+
+import numpy
+import h5py
+import os
+import csv
+import hashlib
+
+class ImageWriter(Filter):
+
+    def __init__(self):
+        super().__init__()
+        self.addInputPort("Path", "")
+        self.addInputPort("Images", [])
+
+    def getImageHash(self,image):
+        keys = list(image.meta.keys())
+        keys.sort()
+        text = ""
+        for k in keys:
+            text = text + str(image.meta[k]) + ';'
+        h = int(hashlib.md5(text.encode('utf-8')).hexdigest(), 16)
+        return h
+
+    def writeH5(self,path,image):
+        file = h5py.File(path, 'w')
+
+        file.create_dataset('origin', data=image.origin)
+
+        fChannel = file.create_group('channel')
+        for k in image.channel:
+            fChannel.create_dataset(k,data=image.channel[k], compression='gzip', compression_opts=9)
+
+        fMeta = file.create_group('meta')
+        for k in image.meta:
+            data = image.meta[k]
+            if type(data) is numpy.ndarray and data.size>1:
+                fMeta.create_dataset(k,data=data, compression='gzip', compression_opts=9)
+            else:
+                fMeta.create_dataset(k,data=data)
+
+        file.close()
+
+    def update(self):
+        super().update()
+
+        images = self.inputs.Images.get()
+        path = self.inputs.Path.get()
+
+        if len(images)<1:
+            return 1
+
+        # check if path is a cdb
+        filename, extension = os.path.splitext(path)
+        extension = str.lower(extension[1:])
+        if extension == 'cdb':
+            # cdb folder
+
+            csvPath = path+'/data.csv'
+            csvData = []
+
+            if os.path.exists(csvPath):
+                with open(csvPath, 'r+') as csvfile:
+                    rows = csv.reader(csvfile, delimiter=',')
+                    for row in rows:
+                        csvData.append(row)
+            else:
+                image0 = images[0]
+                header = list(image0.meta.keys())
+                header.append('FILE')
+                csvData.append(header)
+
+            # build meta to idx map
+            metaIdxMap = {}
+            for (k,v) in enumerate(csvData[0]):
+                metaIdxMap[v] = k
+
+            # check if each image already exists in CDB
+            for image in images:
+                dbRowIdx = -1
+
+                imageHash = self.getImageHash(image)
+                fileName = str(imageHash)+'.h5'
+
+                fileColumnIdx = metaIdxMap['FILE']
+                for i in range(1,len(csvData)):
+                    if csvData[i][fileColumnIdx] == fileName:
+                        dbRowIdx = i
+                        break
+                    # row = csvData[i]
+                    # allRowValuesAreEqual = True
+
+                    # for m in image.meta:
+                    #     idx = metaIdxMap[m]
+                    #     if idx == None:
+                    #         raise ValueError('Image has meta entry not recorded in CDB')
+                    #     if row[idx] != str(image.meta[m]):
+                    #         allRowValuesAreEqual = False
+                    #         break
+
+                    # if allRowValuesAreEqual:
+                    #     dbRowIdx = i
+                    #     break
+
+                if dbRowIdx<0:
+                    newRow = [None]*len(csvData[0])
+                    newRow[metaIdxMap['FILE']] = fileName
+                    for m in image.meta:
+                        idx = metaIdxMap[m]
+                        if idx == None:
+                            raise ValueError('Image has meta information not recorded in CDB')
+                        newRow[idx] = str(image.meta[m])
+                    csvData.append(newRow)
+
+                    with open(csvPath, 'w', newline='') as csvfile:
+                        writer = csv.writer(csvfile, delimiter=',', quotechar='|', quoting=csv.QUOTE_MINIMAL)
+                        for row in csvData:
+                            writer.writerow(row)
+
+                self.writeH5(path+'/'+fileName,image)
+
+        elif extension == '':
+            # normal folder
+            for i,image in enumerate(images):
+                self.writeH5(path+str(i)+'.h5',image)
+
+        return 1

--- a/cinemasci/__init__.py
+++ b/cinemasci/__init__.py
@@ -4,6 +4,7 @@ from .Core import *
 from .CinemaDatabaseReader import *
 from .DatabaseQuery import *
 from .ImageReader import *
+from .ImageWriter import *
 from .ImageRenderer import *
 from .ArtifactSource import *
 from .CinemaArtifactSource import *

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setuptools.setup(
     install_requires=[
         "numpy",
         "scipy",
+        "h5py",
         "matplotlib",
         "py",
         "Pillow",


### PR DESCRIPTION
This PR adds experimental HDF5 support. Now it is possible to read and write a `cinemasci.Image` in hdf5 format. These files have to look like this:
```
root:
    offset: {an array of size two} # e.g., [0,0]
    meta: # a group that stores all meta data associated with the image
        metaInfo1: {an array of any size}  # e.g., Time: [0.1]
        metaInfo2: {an array of any size}  # e.g., Phi: [30]
        metaInfo3: {an array of any size}  # e.g., Theta: [45]
        ...
    channel: # a group that stores all channels of the image
        channel1: {array of size ResX x ResY x ChannelType} # e.g., RGBA : {512x512x4}
        channel2: {array of size ResX x ResY x ChannelType} # e.g., Depth : {512x512x1}
        channel3: {array of size ResX x ResY x ChannelType} # e.g., Some Scalar : {512x512x1}
        channel4: {array of size ResX x ResY x ChannelType} # e.g., Some 2d Vector : {512x512x2}
```
We can discuss this format in our next meeting, but I think it is so simple that we can check if people are willing to write this out.