### PR TITLE
MaskCompositing

### DIFF
--- a/cinemasci/Color.py
+++ b/cinemasci/Color.py
@@ -1,0 +1,19 @@
+from .Core import *
+import numpy
+
+class Color(Filter):
+
+    def __init__(self):
+        super().__init__()
+
+        self.addInputPort('RGBA', (0,0,0,255))
+        self.addOutputPort('RGBA', (0,0,0,255))
+
+    def update(self):
+        super().update()
+
+        self.outputs.RGBA.set(
+          self.inputs.RGBA.get()
+        )
+
+        return 1

--- a/cinemasci/Core.py
+++ b/cinemasci/Core.py
@@ -80,6 +80,9 @@ class Filter():
         # print("-> "+type(self).__name__)
         return
 
+    def help(self):
+        print('Documentation Missing')
+
 class ImageConvertType(Enum):
     COLOR = 0;
     GREYSCALE = 1;

--- a/cinemasci/DepthCompositing.py
+++ b/cinemasci/DepthCompositing.py
@@ -6,9 +6,10 @@ class DepthCompositing(Filter):
     def __init__(self):
         super().__init__()
 
-        self.addInputPort("ImagesA", [])
-        self.addInputPort("ImagesB", [])
-        self.addOutputPort("Images", [])
+        self.addInputPort('ImagesA', [])
+        self.addInputPort('ImagesB', [])
+        self.addInputPort('DepthChannel', 'Depth')
+        self.addOutputPort('Images', [])
 
     def update(self):
         super().update()
@@ -17,8 +18,13 @@ class DepthCompositing(Filter):
         imagesB = self.inputs.ImagesB.get()
 
         nImages = len(imagesA)
+        if nImages!=len(imagesB):
+          print('ERROR', 'Input image lists must be of equal size.' )
+          return 0
 
         results = []
+
+        depthChannel = self.inputs.DepthChannel.get()
 
         for i in range(0,nImages):
             A = imagesA[i]
@@ -26,14 +32,11 @@ class DepthCompositing(Filter):
 
             result = A.copy()
 
-            mask = A.channel['Depth'] > B.channel['Depth']
+            mask = A.channel[depthChannel] > B.channel[depthChannel]
 
             for c in A.channel:
                 data = numpy.copy(A.channel[c])
                 data[mask] = B.channel[c][mask]
-                # print(data.shape)
-                # print(B.channel[c].shape)
-                # numpy.putmask(data,mask,B.channel[c])
                 result.channel[c] = data
 
             results.append( result )

--- a/cinemasci/ImageCanny.py
+++ b/cinemasci/ImageCanny.py
@@ -1,6 +1,6 @@
 from .Core import *
 
-import cv2 
+import cv2
 
 # ImageCanny filter
 # Runs opencv canny edge detection filter, and creates an image of
@@ -9,7 +9,7 @@ class ImageCanny(Filter):
 
   def __init__(self):
     super().__init__();
-    self.addInputPort("Thresholds", [100, 150]); 
+    self.addInputPort("Thresholds", [100, 150]);
     self.addInputPort("Images", []);
     self.addOutputPort("Images", []);
 
@@ -18,20 +18,16 @@ class ImageCanny(Filter):
 
     result = []
     # iterate over all the images in the input images
-    for image in self.inputs.Images.get(): 
+    for image in self.inputs.Images.get():
         # convert the input data into a form that cv uses
         cvimage = cv2.cvtColor(image.channel["RGBA"], cv2.COLOR_RGB2BGR)
         thresholds = self.inputs.Thresholds.get()
 
         # run the canny algorithm, using this object's thresholds
-        canny   = cv2.Canny(cvimage, thresholds[0], thresholds[1]) 
+        canny = cv2.Canny(cvimage, thresholds[0], thresholds[1])/255
 
-        # convert to cinema format
-        cvFinal = cv2.cvtColor(canny, cv2.COLOR_BGR2RGB)
-
-        # copy and save output data
         outImage = image.copy()
-        outImage.channel['RGBA'] = cvFinal 
+        outImage.channel['Canny'] = canny
         result.append(outImage)
 
     self.outputs.Images.set(result)

--- a/cinemasci/MaskCompositing.py
+++ b/cinemasci/MaskCompositing.py
@@ -1,0 +1,79 @@
+from .Core import *
+from .Color import *
+import numpy
+
+class MaskCompositing(Filter):
+
+    def __init__(self):
+        super().__init__()
+
+        self.addInputPort('ImagesA', [])
+        self.addInputPort('ImagesB', [])
+        self.addInputPort('Masks', [])
+        self.addInputPort('ColorChannel', 'RGBA')
+        self.addInputPort('MaskChannel', 'Mask')
+        self.addOutputPort('Images', [])
+
+    def update(self):
+        super().update()
+
+        imagesA = self.inputs.ImagesA.get()
+        imagesB = self.inputs.ImagesB.get()
+        masks = self.inputs.Masks.get()
+
+        if not type(imagesA) is list:
+          imagesA = [imagesA]
+        if not type(imagesB) is list:
+          imagesB = [imagesB]
+
+        nImages = max(len(imagesA),len(imagesB))
+
+        results = []
+
+        colorChannel = self.inputs.ColorChannel.get()
+        maskChannel = self.inputs.MaskChannel.get()
+
+        for i in range(0,nImages):
+            A = imagesA[min(i,len(imagesA)-1)]
+            B = imagesB[min(i,len(imagesB)-1)]
+            M = masks[min(i,len(masks)-1)]
+
+            if type(A) is tuple and type(B) is tuple:
+                print('ERROR', 'Unable to composit just two color inputs')
+                return 0
+
+            result = None
+
+            Ac = None
+            Bc = None
+            Mc = M.channel[maskChannel]
+
+            if type(A) is tuple:
+                result = B.copy()
+                Bc = B.channel[colorChannel]
+                Ac = numpy.full(Bc.shape,A)
+            elif type(B) is tuple:
+                result = A.copy()
+                Ac = A.channel[colorChannel]
+                Bc = numpy.full(Ac.shape,B)
+            else:
+                result = A.copy()
+                Ac = A.channel[colorChannel]
+                Bc = B.channel[colorChannel]
+
+            mask = Mc
+            if numpy.isnan(mask).any():
+              mask = numpy.nan_to_num(mask,nan=0,copy=True)
+
+            if len(Ac.shape)>2 and Ac.shape[2]>1:
+              mask = numpy.stack((mask,) * Ac.shape[2], axis=-1)
+
+            result.channel[colorChannel] = (1-mask)*Ac + mask*Bc
+            if result.channel[colorChannel].dtype != Ac.dtype:
+              result.channel[colorChannel] = result.channel[colorChannel].astype(Ac.dtype)
+
+            results.append( result )
+
+        self.outputs.Images.set(results)
+
+        return 1

--- a/cinemasci/__init__.py
+++ b/cinemasci/__init__.py
@@ -19,6 +19,8 @@ from .ColorMapping import *
 from .DepthCompositing import *
 from .ShaderSSAO import *
 from .ImageGeneratorCNN import *
+from .Color import *
+from .MaskCompositing import *
 
 #
 # new factory function

--- a/examples/demoCDB.ipynb
+++ b/examples/demoCDB.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7b31faa7",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "import cinemasci\n",
@@ -42,11 +44,23 @@
     "depthCompositing.inputs.ImagesB.set(spheresColordByY.outputs.Images, False )\n",
     "depthCompositing.update()\n",
     "\n",
+    "imageCanny = cinemasci.ImageCanny()\n",
+    "imageCanny.inputs.Images.set(depthCompositing.outputs.Images, False)\n",
+    "imageCanny.inputs.Thresholds.set([0,70],False)\n",
+    "imageCanny.update()\n",
+    "\n",
+    "maskCompositing = cinemasci.MaskCompositing()\n",
+    "maskCompositing.inputs.ImagesA.set(depthCompositing.outputs.Images, False )\n",
+    "maskCompositing.inputs.ImagesB.set((0,255,0,255), False )\n",
+    "maskCompositing.inputs.Masks.set(imageCanny.outputs.Images, False )\n",
+    "maskCompositing.inputs.MaskChannel.set('Canny', False )\n",
+    "maskCompositing.update()\n",
+    "\n",
     "ssao = cinemasci.ShaderSSAO()\n",
     "ssao.inputs.Radius.set( 0.1, False )\n",
     "ssao.inputs.Samples.set( 256, False )\n",
     "ssao.inputs.Diff.set( 0.5, False )\n",
-    "ssao.inputs.Images.set( depthCompositing.outputs.Images )\n",
+    "ssao.inputs.Images.set( maskCompositing.outputs.Images )\n",
     "\n",
     "anno = cinemasci.Annotation()\n",
     "anno.inputs.Color.set('white')\n",
@@ -54,24 +68,14 @@
     "anno.inputs.Size.set(15)\n",
     "anno.inputs.Images.set(ssao.outputs.Images)\n",
     "\n",
-    "import PIL\n",
     "from matplotlib import pyplot\n",
     "images = anno.outputs.Images.get();\n",
     "\n",
-    "s = []\n",
     "for i in range(len(images)):   \n",
     "    image = images[i]\n",
     "    matplotlib.pyplot.imshow(image.channel['RGBA'])\n",
     "    matplotlib.pyplot.show()\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "96e244b2",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -90,7 +94,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi David,
this PR adds a new MaskCompositing filter that can compose two images based on a [0,1] mask. As an additional feature the filter also accepts a constant color for either image input, e.g., to highlight something. I updated the `examples/demoCDB.ipynb` file to showcase the new filter. There I first detect edges with the canny filter and then highlight the edges with a light green color through the MaskCompositing filter. This should give you an output like this:
![image](https://user-images.githubusercontent.com/24282273/182835427-64d7dc0a-23c7-40ad-a336-c34a1f094c8c.png)

Best
Jonas